### PR TITLE
get_icon_by_term fix

### DIFF
--- a/R/icons.R
+++ b/R/icons.R
@@ -1,0 +1,21 @@
+#' Search Noun Project using a Term using Python authentication
+#'
+#' @param term word for which you would like to search on Noun Project site
+#' @param num_of_imgs the number of images you would like to get (default = 4 )
+#' @param limit_to_public_domain enter 0 for NO or 1 for YES (default YES)
+#' @param offset how many images would you like to skip (default 0)
+#'
+#' @return ives a list of image details including urls from which they can be
+#' accessed
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' get_icon_by_term("dog")
+#' }
+get_icon_by_term <- function(term, num_of_imgs=4, limit_to_public_domain=1, offset=0) {
+  term_ep <- make_term_endpoint(term, limit_to_public_domain, num_of_imgs, offset)
+  resp <- get_nouns_api(term_ep)
+  httr::content(resp)
+}
+  

--- a/R/np_oauth_python.R
+++ b/R/np_oauth_python.R
@@ -60,7 +60,7 @@ np_oauth <- function(key, secret, icon_num, python_path = Sys.which("python")){
 #' icon_lists <- get_icon_by_term(term)  # gets details of two icons
 #' elephants <- get_pngs_and_show(icon_lists)  # download icons
 #' magick::image_append(elephants)  # show icons - two elephants
-get_icon_by_term <- function(key,
+get_icon_by_term_python <- function(key,
                              secret,
                              term,
                              num_of_imgs = 2,


### PR DESCRIPTION
Changed `get_icon_by_term` implementation to match new R API. I left the same syntax as before and left python version for reference for now.